### PR TITLE
Add appropriate actgrp control option

### DIFF
--- a/src/sgmain.sqlrpgle
+++ b/src/sgmain.sqlrpgle
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 
-ctl-opt dftactgrp(*no);
+ctl-opt dftactgrp(*no) actgrp(*new);
 
 ////////////////////////
 //     Prototypes     //

--- a/src/sgparse.sqlrpgle
+++ b/src/sgparse.sqlrpgle
@@ -20,7 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-ctl-opt dftactgrp(*no);
+
+ctl-opt dftactgrp(*no) actgrp(*caller);
 
 ////////////////////////
 //     Prototypes     //

--- a/src/sgscreen.sqlrpgle
+++ b/src/sgscreen.sqlrpgle
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 
-ctl-opt dftactgrp(*no);
+ctl-opt dftactgrp(*no) actgrp(*caller);
 
 ////////////////////////
 //     Prototypes     //


### PR DESCRIPTION
The utility will now run in its own activation group, including all inner programs. 
Before this change, some program would open files in the QILE activation group and they would remain open until the job ended.
After this change, the files (and other resources) will be closed when the program terminates.